### PR TITLE
Edit exhibited item

### DIFF
--- a/app/controllers/exhibited_items_controller.rb
+++ b/app/controllers/exhibited_items_controller.rb
@@ -23,10 +23,10 @@ class ExhibitedItemsController < ApplicationController
   end
 
   def update
-    exhibitedItem = ExhibitedItem.find(params[:id])
-    exhibitedItem.update(exhibitedItem_params)
-    if exhibitedItem.save
-      redirect_to exhibited_item_path(exhibitedItem.id)
+    @exhibitedItem = ExhibitedItem.find(params[:id])
+    @exhibitedItem.update(exhibitedItem_params)
+    if @exhibitedItem.save
+      redirect_to exhibited_item_path(@exhibitedItem.id)
     else
       render 'edit'
     end

--- a/app/views/exhibited_items/_item.html.erb
+++ b/app/views/exhibited_items/_item.html.erb
@@ -11,7 +11,6 @@
             <span>Sold Out!!</span>
           </div>
           <% end %>
-          <%# //商品が売れていればsold outの表示 %>
 
         </div>
         <div class='item-info'>

--- a/app/views/exhibited_items/edit.html.erb
+++ b/app/views/exhibited_items/edit.html.erb
@@ -122,7 +122,7 @@ app/assets/stylesheets/items/new.css %>
     </div>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', exhibited_item_path(@exhibitedItem.id), class:"back-btn" %>
+      <%= link_to 'もどる', exhibited_item_path(@exhibitedItem.id), class:"back-btn" %>
     </div>
   </div>
   <% end %>

--- a/app/views/exhibited_items/show.html.erb
+++ b/app/views/exhibited_items/show.html.erb
@@ -101,7 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= @exhibitedItem.category.name %>をもっと見る</a>
+  <%= link_to @exhibitedItem.category.name + 'をもっと見る', "#", class: 'another-item'  %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/exhibited_items/show.html.erb
+++ b/app/views/exhibited_items/show.html.erb
@@ -101,7 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%=@exhibitedItem.category.name  %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @exhibitedItem.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
# what
出品商品の編集機能を実装。出品者が商品詳細を表示させると編集ページのリンクが表示される。編集ページには元々入力されている情報が入った状態になっている。
# why
出品商品について入力間違いや変更があったときに対応する機能が必要であるから。